### PR TITLE
fix: pull all issues 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revision history for GHAppy
 
+## 1.0.0.0 -- 2023-01-09
+
+* Minor change triggering a major API change was introduced. Initially GHAppy
+  would only retrieve Issues and PRs that were labeled with the `audit`
+  label. This restriction has been lifted, which means that any previous report
+  has to have this filter added to replicate the former functionality.
+  I.e. files now have to be explicit about every label of an included Issue or
+  PR.
+
 ## 0.2.0.0 -- 2022-12-12
 
 * Introduced the YAML interface and working via the binary.

--- a/GHAppy.cabal
+++ b/GHAppy.cabal
@@ -69,6 +69,12 @@ library
     GHAppy.Types
     GHAppy.YamlInterface
 
+executable Example
+  import:         settings
+  main-is:        Example.hs
+  hs-source-dirs: app
+  build-depends:  GHAppy
+
 executable GHAppy
   import:         settings
   main-is:        Main.hs

--- a/app/Example.hs
+++ b/app/Example.hs
@@ -1,4 +1,4 @@
-module Example (main) where
+module Main (main) where
 
 import Control.Monad (void)
 import Control.Monad.Freer (Eff, Member)
@@ -23,6 +23,7 @@ main = do
       getLinkedFile ImagesDir logoCropped (linkedFiles <> logoCropped)
       -- Download all the issues
       pullIssues
+      saveAvailableIssues
       -- Compose our report
       s <- runCompose auditReport
       -- Generate our pdf.

--- a/src/GHAppy.hs
+++ b/src/GHAppy.hs
@@ -423,7 +423,6 @@ pullIssuesImpl = goFromUntil 1 (== mempty) pullPage
                 , ("state", Just "all")
                 , ("direction", Just "asc")
                 , ("page", Just $ fromString $ show n)
-                , ("labels", Just "audit")
                 ]
                 reqIssues
         getResponseBody <$> httpBS reqIssues'


### PR DESCRIPTION
There is an issue where only issues/PRs labelled with `audit` get pulled. This is a fix.

There also some additional changes in error reporting - the number of the issue that cannot be found is now reported. 