### PR TITLE
add checksum feature to GHAppy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist-newstyle
 token.txtresult
 result
 token.txt
+.token.txt
+_out/
+hie.yaml
 .vscode
 .direnv
 .pre-commit-config.yaml

--- a/GHAppy.cabal
+++ b/GHAppy.cabal
@@ -27,7 +27,7 @@ common settings
     , mtl
     , optparse-applicative
     , pandoc
-    , SHA
+    , SHA                   ==1.6.4.4
     , shell-conduit
     , text
     , yaml

--- a/GHAppy.cabal
+++ b/GHAppy.cabal
@@ -43,6 +43,7 @@ common settings
     GADTs
     GeneralizedNewtypeDeriving
     LambdaCase
+    NamedFieldPuns
     OverloadedStrings
     RankNTypes
     RecordWildCards

--- a/GHAppy.cabal
+++ b/GHAppy.cabal
@@ -27,6 +27,7 @@ common settings
     , mtl
     , optparse-applicative
     , pandoc
+    , SHA                   ==1.6.4.4
     , text
     , yaml
 

--- a/GHAppy.cabal
+++ b/GHAppy.cabal
@@ -27,11 +27,13 @@ common settings
     , mtl
     , optparse-applicative
     , pandoc
-    , SHA                   ==1.6.4.4
+    , SHA
+    , shell-conduit
     , text
     , yaml
 
   default-extensions:
+    BlockArguments
     ConstraintKinds
     DataKinds
     DeriveAnyClass
@@ -63,12 +65,13 @@ common settings
     -fprint-explicit-kinds
 
 library
-  import:          settings 
+  import:          settings
   hs-source-dirs:  src
   exposed-modules:
     GHAppy
     GHAppy.OptParser
     GHAppy.Types
+    GHAppy.Utils
     GHAppy.YamlInterface
 
 executable Example

--- a/example/report2.yaml
+++ b/example/report2.yaml
@@ -7,78 +7,75 @@ Composer:
       link: https://raw.githubusercontent.com/mlabs-haskell/audit-report-template/master/linked-files/disclaimer.md
 
   - NewPage: 0
+
 #-------------------------------------------------------------------------------
 # Audit Background
-  - Issue:
+  - CheckSum:
       level: 0
       number: 1
-
-  - CheckSum:
-      files:
-        - app/Main.hs
-        - src/Canonical/Shared.hs
-        - src/Canonical/DebugUtilities.h
-        - src/Canonical/Vesting.hs
-      commitHash: 703566b6e9e49ab89605dc196059086a40267134
-
+      info:
+        files:
+          - benchmark-results.yaml
+          - cabal-haskell.nix.project
+          - flake.nix
+          - hash-checks/Main.hs
+          - indigo.cabal
+          - serialise/Main.hs
+          - src/Indigo/Contracts/Vesting
+          - src/Indigo/Utils/Helpers.hs
+          - src/Indigo/Utils/Utils.hs
+          - tests
+        commitHash: a9c9b3ed6675721197656bde8dc7a8871cb608cc
 
   - NewPage: 0
-#-------------------------------------------------------------------------------
-# Findings
-  - Header:
-      level: 1
-      text: Findings
 
-  - Issue: # Summary
-      level: 1
-      number: 20
+# Findings and Reccomendations
+  - Issue:
+      level: 0
+      number: 11
 
   - NewPage: 0
 
   # Vulnerabilities
   - Header:
-      level: 2
+      level: 1
       text: Vulnerabilities
 
   - AllIssuesThat:
-      level: 2
+      level: 1
       filters:
-        - hasLabel: audit
-        - hasLabel: audit-findings
+        - hasLabel: "vulnerability"
         - isOpen: true
 
   - NewPage: 0
+
+  # Hypotheses
+  - Header:
+      level: 1
+      text: Hypotheses
+
+  - AllIssuesThat:
+      level: 1
+      filters:
+        - hasLabel: "hypothesis"
+        - isOpen: true
 
   # Recommendation
   - Header:
-      level: 2
+      level: 1
       text: Recommendations
 
   - AllIssuesThat:
-      level: 2
+      level: 1
       filters:
-        - hasLabel: audit
-        - hasLabel: recommendation
+        - hasLabel: "recommendation"
         - isOpen: true
 
-  - NewPage: 0
-#-------------------------------------------------------------------------------
-  # Testing
-  - Issue:
-      level: 0
-      number: 21
 
   - NewPage: 0
-#-------------------------------------------------------------------------------
-  # Conclusion
-  - Issue:
-      level: 0
-      number: 22
 
-  - NewPage: 0
 #-------------------------------------------------------------------------------
 # Appendix
-  # Findings
   - Header:
       level: 1
       text: Appendix

--- a/example/report2.yaml
+++ b/example/report2.yaml
@@ -15,6 +15,7 @@ Composer:
 
   - CheckSum:
       files:
+        - app/Main.hs
         - src/Canonical/Shared.hs
         - src/Canonical/DebugUtilities.h
         - src/Canonical/Vesting.hs

--- a/example/report2.yaml
+++ b/example/report2.yaml
@@ -1,55 +1,100 @@
 Composer:
-  
+
+#-------------------------------------------------------------------------------
+# Disclaimer
   - RawMd:
-      level: 0 
+      level: 0
       link: https://raw.githubusercontent.com/mlabs-haskell/audit-report-template/master/linked-files/disclaimer.md
 
-  - Header: 
-      level: 1 
-      text: Contents
-    
+  - NewPage: 0
+#-------------------------------------------------------------------------------
+# Audit Background
   - Issue:
-      level: 1
+      level: 0
       number: 1
-    
-  - Issue:
-      level: 1
-      number: 6
+
+  - CheckSum:
+      files:
+        - src/Canonical/Shared.hs
+        - src/Canonical/DebugUtilities.h
+        - src/Canonical/Vesting.hs
+      commitHash: 703566b6e9e49ab89605dc196059086a40267134
+
 
   - NewPage: 0
-
+#-------------------------------------------------------------------------------
+# Findings
   - Header:
       level: 1
-      text: "Reviews"
+      text: Findings
 
-  - AllIssuesThat:
-      level: 2 
-      filters:
-        - hasLabel: "audit"
-        - hasLabel: "not-fixed"
-        - isOpen: true
-          
+  - Issue: # Summary
+      level: 1
+      number: 20
+
   - NewPage: 0
 
-  - Header: 
-      level: 2 
-      text: "Considered Fixed"
-    
-  - AllIssuesThat: 
-      level: 2 
+  # Vulnerabilities
+  - Header:
+      level: 2
+      text: Vulnerabilities
+
+  - AllIssuesThat:
+      level: 2
       filters:
-        - hasLabel: "audit"
-        - hasLabel: "fixed"
+        - hasLabel: audit
+        - hasLabel: audit-findings
         - isOpen: true
+
+  - NewPage: 0
+
+  # Recommendation
+  - Header:
+      level: 2
+      text: Recommendations
+
+  - AllIssuesThat:
+      level: 2
+      filters:
+        - hasLabel: audit
+        - hasLabel: recommendation
+        - isOpen: true
+
+  - NewPage: 0
+#-------------------------------------------------------------------------------
+  # Testing
+  - Issue:
+      level: 0
+      number: 21
+
+  - NewPage: 0
+#-------------------------------------------------------------------------------
+  # Conclusion
+  - Issue:
+      level: 0
+      number: 22
+
+  - NewPage: 0
+#-------------------------------------------------------------------------------
+# Appendix
+  # Findings
+  - Header:
+      level: 1
+      text: Appendix
+
+  - RawMd:
+      level: 1
+      link: https://raw.githubusercontent.com/mlabs-haskell/audit-report-template/master/linked-files/vulnerability-types.md
+
+#-------------------------------------------------------------------------------
 
 GHAppy:
   - GetLinkedFile:
       location: Images
       name: MLabs-logo.jpg
       link: https://raw.githubusercontent.com/mlabs-haskell/audit-report-template/master/linked-files/images/MLabs-logo.jpg
-      
+
   - GetLinkedFile:
       location: Images
-      name: MLabs-logo-cropped.jpg 
+      name: MLabs-logo-cropped.jpg
       link: https://raw.githubusercontent.com/mlabs-haskell/audit-report-template/master/linked-files/images/MLabs-logo-cropped.jpg
-

--- a/run.sh
+++ b/run.sh
@@ -2,9 +2,9 @@
 # or nix run github:mlabs-haskell/GHAppy
 
 cabal run GHAppy -- \
-	-a $(cat ./token.txt) \
-	-o "out" \
+	-a $(cat ./.token.txt) \
+	-o "_out" \
 	-f "outFile" \
-	-r "mlabs-haskell/optim-onchain-audit" \
-	-u "cstml" \
+	-r "jpg-store/vesting-contract" \
+	-u "IAmPara0x" \
 	-i ./example/report2.yaml

--- a/run.sh
+++ b/run.sh
@@ -6,5 +6,5 @@ cabal run GHAppy -- \
 	-o "_out" \
 	-f "outFile" \
 	-r "jpg-store/vesting-contract" \
-	-u "IAmPara0x" \
+	-u "cstml" \
 	-i ./example/report2.yaml

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,6 @@ cabal run GHAppy -- \
 	-a $(cat ./.token.txt) \
 	-o "_out" \
 	-f "outFile" \
-	-r "jpg-store/vesting-contract" \
-	-u "cstml" \
+	-r "mlabs-haskell/indigo-smart-contracts-audit-2" \
+	-u "IAmPara0x" \
 	-i ./example/report2.yaml

--- a/src/GHAppy.hs
+++ b/src/GHAppy.hs
@@ -600,6 +600,7 @@ runPandoc fs = do
         , optInputFiles = Just [mdFile]
         , optTemplate = Just pTplFl
         }
+
   sendM $ removeFile pTplFl
 
 getPreamble :: (Members '[Reader Settings] effs, LastMember IO effs) => Eff effs String

--- a/src/GHAppy.hs
+++ b/src/GHAppy.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 {- | 'GHappy' is a library meant to ease the creation of Audit Reports via the
  use of Git Hub Issues. The workflow can be described as follows:
 
@@ -284,7 +282,7 @@ data Composer a where
   AddHeader :: Integer -> String -> Composer ()
   -- | Add raw markdown file from GitHub raw file url, at a specific level.
   AddRawMd :: Integer -> String -> Composer ()
-  -- | Add raw markdown file from GitHub raw file url, at a specific level.
+  -- | Add checksum info for the given filePath and commithash of the repo.
   AddCheckSumInfo :: CommitHash -> [FilePath] -> Composer ()
 
 makeEffect ''Composer
@@ -399,6 +397,7 @@ makeRequestBS url =
     initReq <- parseRequest url
     getResponseBody <$> httpBS initReq
 
+-- Add information about all the files and their checksums along with the commit hash.
 addCheckSums :: forall effs. EffGH effs => CommitHash -> [FilePath] -> Eff (Writer [Leaf] ': effs) ()
 addCheckSums commitHash files = do
   Settings {repository} <- ask
@@ -430,6 +429,7 @@ addCheckSums commitHash files = do
 
   tell [Leaf {preamble = [checkSumTemplate], level = 1, issueN = Nothing}]
 
+-- given a commithash and a filePath, get the specified file from the github repository and compute the hash of it.
 getHashOfGHFile :: forall effs. EffGH effs => CommitHash -> FilePath -> Eff effs String
 getHashOfGHFile commitHash filePath = do
   Settings {repository} <- ask

--- a/src/GHAppy/Types.hs
+++ b/src/GHAppy/Types.hs
@@ -65,3 +65,12 @@ instance FromJSON Entry
 instance ToJSON Entry
 
 type CommitHash = String
+
+data CheckSumInfo = CheckSumInfo
+  { commitHash :: CommitHash
+  , files :: [FilePath]
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON CheckSumInfo
+instance ToJSON CheckSumInfo

--- a/src/GHAppy/Types.hs
+++ b/src/GHAppy/Types.hs
@@ -63,3 +63,5 @@ data Entry = Entry
 
 instance FromJSON Entry
 instance ToJSON Entry
+
+type CommitHash = String

--- a/src/GHAppy/Utils.hs
+++ b/src/GHAppy/Utils.hs
@@ -1,0 +1,31 @@
+module GHAppy.Utils (isDirectory, formatChecksum, getAllFiles, repoName, removeRepoPath) where
+
+import Data.List (intersperse)
+import System.Directory (listDirectory)
+import System.FilePath (hasExtension, (</>))
+import Text.Printf (printf)
+
+wordsWhen :: (Char -> Bool) -> String -> [String]
+wordsWhen p s = case dropWhile p s of
+  "" -> []
+  s' -> w : wordsWhen p s''
+    where
+      (w, s'') = break p s'
+
+isDirectory :: FilePath -> Bool
+isDirectory = not . hasExtension . last . wordsWhen (== '/')
+
+formatChecksum :: String -> FilePath -> String
+formatChecksum fileHash = printf "%s...%s  %s" (take 4 fileHash) (drop 60 fileHash)
+
+repoName :: String -> String
+repoName = last . wordsWhen (== '/')
+
+removeRepoPath :: String -> String
+removeRepoPath = mconcat . intersperse "/" . drop 2 . wordsWhen (== '/')
+
+getAllFiles :: [FilePath] -> IO [FilePath]
+getAllFiles [] = return []
+getAllFiles (f : fs)
+  | isDirectory f = listDirectory f >>= (getAllFiles . (fs ++) . map (f </>))
+  | otherwise = (f :) <$> getAllFiles fs


### PR DESCRIPTION
### Syntax for the checksum

```yaml
  - CheckSum:
      level: 0
      number: 1
      info:
        files:
          - path/to/dir
          - path/to/file1.hs
          - path/to/file.hs
        commitHash: a9c9b3ed6675721197656bde8dc7a8871cb608cc
 ```

Here the `number` is the issue number where we want to include the checksum details. Then GHAppy will search for a token `INCLUDE CheckSum` in the body of that issue and then will replace that token with the checksum information.

If there is a dir specified in the files then GHAppy will clone the repo locally else it will use get requests to the body of the files specified.
